### PR TITLE
Update a8s controllers for sales demo

### DIFF
--- a/deployment/a8s-backup-manager.yaml
+++ b/deployment/a8s-backup-manager.yaml
@@ -75,9 +75,6 @@ spec:
                     description: Type is a short camelCase message describing the last observed condition of the backup or recovery. Can be one of `succeeded`, `inProgress`, `failed`.
                     type: string
                 type: object
-              podUsedIP:
-                description: PodUsedIP is used to continue checking the status of a backup from the same Backup Agent.
-                type: string
               podUsedNamespacedName:
                 description: 'PodUsedNamespacedName is the namespaced name of the DSI Pod to which the backup request was sent. TODO: Represent this jointly with `PodUsedID` (below) via a PodRef.'
                 type: string
@@ -247,10 +244,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - backups.anynines.com
   resources:
@@ -392,6 +398,22 @@ metadata:
   namespace: a8s-system
 ---
 apiVersion: v1
+data:
+  config.yaml: |
+    config:
+      cloud_configuration:
+        provider: "AWS"
+        container: "a8s-postgresql"
+        secret_name: "aws-credentials"
+        region: "eu-central-1"
+      encryption:
+        password: "password"
+kind: ConfigMap
+metadata:
+  name: backup-storage-config
+  namespace: a8s-system
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -440,7 +462,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: c4aeb71c-dd2a-4e6e-9385-1c3bb839307c.de.a9s.eu/demo/a8s-backup-manager:0.1.0
+        image: c4aeb71c-dd2a-4e6e-9385-1c3bb839307c.de.a9s.eu/demo/a8s-backup-manager:v0.2.0
         livenessProbe:
           httpGet:
             path: /healthz
@@ -463,6 +485,13 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /etc/config
+          name: config-volume
       securityContext:
         runAsUser: 65532
       terminationGracePeriodSeconds: 10
+      volumes:
+      - configMap:
+          name: backup-storage-config
+        name: config-volume

--- a/deployment/cluster-operators.yaml
+++ b/deployment/cluster-operators.yaml
@@ -37,810 +37,62 @@ spec:
           spec:
             description: PostgresqlSpec defines the desired state of Postgresql
             properties:
-              customParameters:
-                description: CustomParameters available for user configuration
+              backupAgentImage:
+                description: BackupAgentImage is the name of the container image to use for the backup agent sidecar container.
+                type: string
+              image:
+                description: Image is the name of the container image to use for the data service containers.
+                type: string
+              replicas:
+                default: 1
+                description: Replicas is the number of replicas of the data service in the cluster. Replicas of the PostgreSQL resource will constitute a streaming replication cluster. This value should be an odd number (with the exception of the value 0) to ensure the resultant cluster can establish quorum. Only scaling up is supported and not scaling down of replicas.
+                format: int32
+                minimum: 0
+                type: integer
+              resources:
+                default:
+                  limits:
+                    cpu: "2"
+                    memory: 2Gi
+                  requests:
+                    cpu: "2"
+                    memory: 2Gi
+                description: Resources is the desired compute resource requirements of PostgreSQL container within a pod in the cluster. Updating resources causes the replicas of the PostgreSQL cluster to be killed and recreated one at a time, which could potentially lead to downtime if something goes wrong during the update.
                 properties:
-                  configuration:
-                    description: Configuration settings
-                    properties:
-                      idleInTransactionSessionTimeout:
-                        type: string
-                      statementTimeout:
-                        type: string
-                    type: object
-                  continuousArchiving:
-                    description: ContinuousArchiving ..
-                    properties:
-                      string:
-                        type: integer
-                    type: object
-                  copyFrom:
-                    type: string
-                  dataChecksums:
-                    type: boolean
-                  enableContinuousArchiving:
-                    type: boolean
-                  extensions:
-                    items:
-                      type: string
-                    type: array
-                  logging:
-                    description: Logging settings
-                    properties:
-                      clientMinMessages:
-                        type: string
-                      logErrorVerbosity:
-                        type: string
-                      logLevel:
-                        type: string
-                      logStatement:
-                        type: string
-                      pgLogMinErrorStatement:
-                        type: string
-                      pgLogMinMessages:
-                        type: string
-                      repmgrLoglevel:
-                        type: string
-                      tempFiles:
-                        type: string
-                    type: object
-                  plan:
-                    description: Plan is variables associated allocating resources for your a9s PostgreSQL plans
-                    properties:
-                      effectiveCacheSize:
-                        type: string
-                      maxConnections:
-                        type: integer
-                      sharedBuffers:
-                        type: integer
-                      workMem:
-                        type: string
-                    type: object
-                  statistics:
-                    description: Statistics enables timing of database I/O calls
-                    properties:
-                      trackIOTiming:
-                        type: string
-                    type: object
-                  tempFileLimit:
-                    type: integer
-                type: object
-              genericSettings:
-                description: Foo is an example field of Postgres. Edit Postgres_types.go to remove/update
-                properties:
-                  affinity:
-                    description: Affinity is a group of affinity scheduling rules.
-                    properties:
-                      nodeAffinity:
-                        description: Describes node affinity scheduling rules for the pod.
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
-                            items:
-                              description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
-                              properties:
-                                preference:
-                                  description: A node selector term, associated with the corresponding weight.
-                                  properties:
-                                    matchExpressions:
-                                      description: A list of node selector requirements by node's labels.
-                                      items:
-                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                        properties:
-                                          key:
-                                            description: The label key that the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                            type: string
-                                          values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      description: A list of node selector requirements by node's fields.
-                                      items:
-                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                        properties:
-                                          key:
-                                            description: The label key that the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                            type: string
-                                          values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                weight:
-                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
-                                  format: int32
-                                  type: integer
-                              required:
-                              - preference
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
-                            properties:
-                              nodeSelectorTerms:
-                                description: Required. A list of node selector terms. The terms are ORed.
-                                items:
-                                  description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
-                                  properties:
-                                    matchExpressions:
-                                      description: A list of node selector requirements by node's labels.
-                                      items:
-                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                        properties:
-                                          key:
-                                            description: The label key that the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                            type: string
-                                          values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      description: A list of node selector requirements by node's fields.
-                                      items:
-                                        description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                        properties:
-                                          key:
-                                            description: The label key that the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
-                                            type: string
-                                          values:
-                                            description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                type: array
-                            required:
-                            - nodeSelectorTerms
-                            type: object
-                        type: object
-                      podAffinity:
-                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
-                            items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                              properties:
-                                podAffinityTerm:
-                                  description: Required. A pod affinity term, associated with the corresponding weight.
-                                  properties:
-                                    labelSelector:
-                                      description: A label query over a set of resources, in this case pods.
-                                      properties:
-                                        matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                          items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                            properties:
-                                              key:
-                                                description: key is the label key that the selector applies to.
-                                                type: string
-                                              operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                type: string
-                                              values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                            items:
-                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources, in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                      items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                      podAntiAffinity:
-                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
-                            items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
-                              properties:
-                                podAffinityTerm:
-                                  description: Required. A pod affinity term, associated with the corresponding weight.
-                                  properties:
-                                    labelSelector:
-                                      description: A label query over a set of resources, in this case pods.
-                                      properties:
-                                        matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                          items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                            properties:
-                                              key:
-                                                description: key is the label key that the selector applies to.
-                                                type: string
-                                              operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                                type: string
-                                              values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
-                            items:
-                              description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources, in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                      items:
-                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                    type: object
-                  backupAgentImage:
-                    type: string
-                  command:
-                    items:
-                      type: string
-                    type: array
-                  customConfig:
-                    items:
-                      type: string
-                    type: array
-                  dnsPolicy:
-                    description: DNSPolicy defines how a pod's DNS will be configured.
-                    type: string
-                  hostNetwork:
-                    type: boolean
-                  image:
-                    type: string
-                  imagePullPolicy:
-                    description: PullPolicy describes a policy for if/when to pull a container image
-                    type: string
-                  imagePullSecrets:
-                    items:
-                      description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
-                      properties:
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                      type: object
-                    type: array
-                  nodeSelector:
+                  limits:
                     additionalProperties:
-                      type: string
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
-                  podAnnotations:
+                  requests:
                     additionalProperties:
-                      type: string
-                    type: object
-                  priorityClassName:
-                    type: string
-                  replicas:
-                    format: int32
-                    type: integer
-                  resources:
-                    description: ResourceRequirements describes the compute resource requirements.
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                    type: object
-                  securityContext:
-                    description: PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.
-                    properties:
-                      fsGroup:
-                        description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
-                        format: int64
-                        type: integer
-                      fsGroupChangePolicy:
-                        description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified defaults to "Always".'
-                        type: string
-                      runAsGroup:
-                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-                        format: int64
-                        type: integer
-                      runAsNonRoot:
-                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                        type: boolean
-                      runAsUser:
-                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-                        format: int64
-                        type: integer
-                      seLinuxOptions:
-                        description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
-                        properties:
-                          level:
-                            description: Level is SELinux level label that applies to the container.
-                            type: string
-                          role:
-                            description: Role is a SELinux role label that applies to the container.
-                            type: string
-                          type:
-                            description: Type is a SELinux type label that applies to the container.
-                            type: string
-                          user:
-                            description: User is a SELinux user label that applies to the container.
-                            type: string
-                        type: object
-                      seccompProfile:
-                        description: The seccomp options to use by the containers in this pod.
-                        properties:
-                          localhostProfile:
-                            description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
-                            type: string
-                          type:
-                            description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
-                            type: string
-                        required:
-                        - type
-                        type: object
-                      supplementalGroups:
-                        description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
-                        items:
-                          format: int64
-                          type: integer
-                        type: array
-                      sysctls:
-                        description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
-                        items:
-                          description: Sysctl defines a kernel parameter to be set
-                          properties:
-                            name:
-                              description: Name of a property to set
-                              type: string
-                            value:
-                              description: Value of a property to set
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
-                      windowsOptions:
-                        description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                        properties:
-                          gmsaCredentialSpec:
-                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
-                            type: string
-                          gmsaCredentialSpecName:
-                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
-                            type: string
-                          runAsUserName:
-                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
-                            type: string
-                        type: object
-                    type: object
-                  serviceAnnotations:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  shutdownConfigMap:
-                    type: string
-                  storage:
-                    description: PostgresStorage defines the structure used to store the Redis Data
-                    properties:
-                      emptyDir:
-                        description: Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.
-                        properties:
-                          medium:
-                            description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                            type: string
-                          sizeLimit:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                        type: object
-                      keepAfterDeletion:
-                        type: boolean
-                      persistentVolumeClaim:
-                        description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
-                        properties:
-                          apiVersion:
-                            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                            type: string
-                          kind:
-                            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          metadata:
-                            description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                            type: object
-                          spec:
-                            description: 'Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                            properties:
-                              accessModes:
-                                description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                items:
-                                  type: string
-                                type: array
-                              dataSource:
-                                description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot - Beta) * An existing PVC (PersistentVolumeClaim) * An existing custom resource/object that implements data population (Alpha) In order to use VolumeSnapshot object types, the appropriate feature gate must be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the specified data source is not supported, the volume will not be created and the failure will be reported as an event. In the future, we plan to support more data source types and the behavior of the provisioner may change.'
-                                properties:
-                                  apiGroup:
-                                    description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
-                                    type: string
-                                  kind:
-                                    description: Kind is the type of resource being referenced
-                                    type: string
-                                  name:
-                                    description: Name is the name of resource being referenced
-                                    type: string
-                                required:
-                                - kind
-                                - name
-                                type: object
-                              resources:
-                                description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                                properties:
-                                  limits:
-                                    additionalProperties:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                    type: object
-                                  requests:
-                                    additionalProperties:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                    type: object
-                                type: object
-                              selector:
-                                description: A label query over volumes to consider for binding.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                    items:
-                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                    type: object
-                                type: object
-                              storageClassName:
-                                description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                                type: string
-                              volumeMode:
-                                description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
-                                type: string
-                              volumeName:
-                                description: VolumeName is the binding reference to the PersistentVolume backing this claim.
-                                type: string
-                            type: object
-                          status:
-                            description: 'Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                            properties:
-                              accessModes:
-                                description: 'AccessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                items:
-                                  type: string
-                                type: array
-                              capacity:
-                                additionalProperties:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: Represents the actual resources of the underlying volume.
-                                type: object
-                              conditions:
-                                description: Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
-                                items:
-                                  description: PersistentVolumeClaimCondition contails details about state of pvc
-                                  properties:
-                                    lastProbeTime:
-                                      description: Last time we probed the condition.
-                                      format: date-time
-                                      type: string
-                                    lastTransitionTime:
-                                      description: Last time the condition transitioned from one status to another.
-                                      format: date-time
-                                      type: string
-                                    message:
-                                      description: Human-readable message indicating details about last transition.
-                                      type: string
-                                    reason:
-                                      description: Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
-                                      type: string
-                                    status:
-                                      type: string
-                                    type:
-                                      description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
-                                      type: string
-                                  required:
-                                  - status
-                                  - type
-                                  type: object
-                                type: array
-                              phase:
-                                description: Phase represents the current phase of PersistentVolumeClaim.
-                                type: string
-                            type: object
-                        type: object
-                    type: object
-                  tolerations:
-                    items:
-                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
-                      properties:
-                        effect:
-                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
-                          type: string
-                        key:
-                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
-                          type: string
-                        operator:
-                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
-                          type: string
-                        tolerationSeconds:
-                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
-                          format: int64
-                          type: integer
-                        value:
-                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
-                          type: string
-                      type: object
-                    type: array
-                  users:
-                    items:
-                      type: string
-                    type: array
-                type: object
-              internalParameters:
-                description: InternalParameters available for Kubernetes operator configuration
-                properties:
-                  adminCredentials:
-                    description: AdminCredentials contains admin DB user credentials
-                    properties:
-                      password:
-                        type: string
-                      username:
-                        type: string
-                    type: object
-                  port:
-                    type: integer
-                  replication:
-                    type: boolean
-                  replicationCredentials:
-                    description: ReplicationCredentials contains admin DB user credentials
-                    properties:
-                      password:
-                        type: string
-                      username:
-                        type: string
-                    type: object
-                  ssl:
-                    description: SSL defined whether ssl is enabled
-                    properties:
-                      trackIOTiming:
-                        type: boolean
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                 type: object
+            required:
+            - backupAgentImage
+            - image
             type: object
           status:
             description: PostgresqlStatus defines the observed state of Postgresql
             properties:
-              nodes:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file'
-                items:
-                  type: string
-                type: array
-            required:
-            - nodes
+              clusterStatus:
+                description: ClusterStatus is a summary of the current status of the cluster. Careful, if ReadyReplicas < 'spec.Replicas' or `spec.Replicas` == 0 the status equals "NotRunning".
+                type: string
+              error:
+                type: string
+              readyReplicas:
+                format: int32
+                type: integer
             type: object
         type: object
     served: true
@@ -890,18 +142,42 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  - apps
+  resources:
+  - endpoints
+  verbs:
+  - delete
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - list
+  - watch
+- apiGroups:
+  - ""
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
   - secrets
   - serviceaccounts
-  - services
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - statefulsets
   verbs:
   - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - postgresql.anynines.com
@@ -909,7 +185,15 @@ rules:
   - postgresqls
   verbs:
   - list
+  - update
   - watch
+- apiGroups:
+  - postgresql.anynines.com
+  resources:
+  - postgresqls/status
+  verbs:
+  - get
+  - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resourceNames:
@@ -1090,7 +374,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: c4aeb71c-dd2a-4e6e-9385-1c3bb839307c.de.a9s.eu/demo/postgresql-controller:0.1.0
+        image: c4aeb71c-dd2a-4e6e-9385-1c3bb839307c.de.a9s.eu/demo/postgresql-controller:v0.3.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deployment/instance.yaml
+++ b/deployment/instance.yaml
@@ -3,12 +3,11 @@ kind: Postgresql
 metadata:
   name: demo-pg-cluster
 spec:
-  genericSettings:
-    replicas: 3
-    image: "registry.opensource.zalan.do/acid/spilo-13:2.0-p2"
-    backupAgentImage: "c4aeb71c-dd2a-4e6e-9385-1c3bb839307c.de.a9s.eu/demo/backup-agent:0.3.0"
-    resources:
-      requests:
-        cpu: 100m
-      limits:
-        memory: 100Mi
+  replicas: 3
+  image: "registry.opensource.zalan.do/acid/spilo-13:2.0-p2"
+  backupAgentImage: "c4aeb71c-dd2a-4e6e-9385-1c3bb839307c.de.a9s.eu/demo/backup-agent:0.3.0"
+  resources:
+    requests:
+      cpu: 100m
+    limits:
+      memory: 100Mi


### PR DESCRIPTION
Since the last commit to this repo, new features have been added to a8s, and we want to show them in the sales videos.

To that end, this repo must be updated with up-to-date versions of the a8s control plane components, because we use it as a base for the sales videos scripts.

Note that this doesn't mean all the new a8s features must be shown in the demo steps in this repo, and in fact they are not. It suffices to have here YAML manifests with up-to-date a8s components. Updating the demo script in this repo is left as a follow up, future PR.